### PR TITLE
Adding VS Code config folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,python,jupyternotebooks,react,vscode
+
+# Adding Visual Studio Code config folder
+.vscode/


### PR DESCRIPTION
Tiny fix to .gitignore to include the .vscode/ folder.

Closes #11.